### PR TITLE
Increment Redis version number

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,7 @@ base64 = "0.13"
 serde_json = "1.0"
 serde_derive = "1.0"
 serde = "1.0"
-redis = "0.17"
+redis = "0.18"
 time = "0.1"
 uuid = { version = "0.8.1", features = ["v4"] }
 captcha = { git = "https://github.com/daniel-e/captcha.git" }


### PR DESCRIPTION
Redis 0.17 depends on combine 4.5.0 which appears to not properly compile anymore.

I couldn't figure out exactly why, I suspect it's because bytes_05 is an optional dependency in combine 4.5.0 and cargo somehow confuses itself because another crate depends on bytes_05. 

Using redis 0.18 appears to fix it.